### PR TITLE
Fixed ToolkitCore on 1.6.

### DIFF
--- a/toolkitcore/ToolkitCore.csproj
+++ b/toolkitcore/ToolkitCore.csproj
@@ -30,7 +30,7 @@
     <WarningLevel>4</WarningLevel>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.5.4062" />
+    <PackageReference Include="Krafs.Rimworld.Ref" Version="1.6.4503-beta" />
     <PackageReference Include="Lib.Harmony" Version="2.3.3" ExcludeAssets="runtime">
       <IncludeAssets>compile; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/toolkitcore/Windows/Window_MessageLog.cs
+++ b/toolkitcore/Windows/Window_MessageLog.cs
@@ -14,12 +14,12 @@ namespace ToolkitCore.Windows
         {
             Listing_Standard listingStandard = new Listing_Standard();
             listingStandard.Begin(inRect);
-            listingStandard.Label("Twitch Message Log", -1f, (string)null);
+            listingStandard.Label("Twitch Message Log");
             listingStandard.ColumnWidth = ((Rect)inRect).width * 0.3f;
             if (TwitchWrapper.Client != null)
             {
                 bool isConnected = TwitchWrapper.Client.IsConnected;
-                listingStandard.Label(isConnected ? TCText.ColoredText("Connected", Color.green) : TCText.ColoredText("Not Connected", Color.red), -1f, (string)null);
+                listingStandard.Label(isConnected ? TCText.ColoredText("Connected", Color.green) : TCText.ColoredText("Not Connected", Color.red));
                 if (listingStandard.ButtonText(isConnected ? "Disconnect" : "Connect", (string)null))
                     TwitchWrapper.Client.Disconnect();
             }


### PR DESCRIPTION
The signature of `Listing_Standard.Label` is no longer `Listing_Standard.Label(string, int, string)`.